### PR TITLE
PlatformIO library descriptor added

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,0 +1,18 @@
+{
+    "name": "Adafruit-PCD8544",
+    "keywords": "5110, lcd, pcd8544",
+    "description": "Espressif ESP8266 port of the Adafruit PCD8544 library",
+    "repository":
+    {
+        "type": "git",
+        "url": "https://github.com/WereCatf/Adafruit-PCD8544-Nokia-5110-LCD-library.git",
+        "branch": "esp8266"
+    },
+    "dependencies":
+    {
+      "name": "Adafruit-GFX",
+      "frameworks": "arduino"
+    },
+    "frameworks": "arduino",
+    "platforms": "espressif"
+}


### PR DESCRIPTION
As there isn't a working one listed yet, I'd like to add this library as a [PlatformIO library](http://platformio.org/lib) so it can be easily used for any Arduino-based ESP8266 project.

If you accept this PR I would publish the link to your repository to PlatformIO.
